### PR TITLE
Allow Access to Jetson GPIO pin from within a container

### DIFF
--- a/Carplate-yolov5/requirements.txt
+++ b/Carplate-yolov5/requirements.txt
@@ -20,3 +20,6 @@ pandas
 
 # extras --------------------------------------
 thop  # FLOPs computation
+
+# sensors -------------------------------------
+Jetson.GPIO

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 xhost +local:
-sudo docker run -it --rm --runtime nvidia --network host --device /dev/video0:/dev/video0:mrw -e DISPLAY=$DISPLAY -v /tmp/argus_socket:/tmp/argus_socket -v /tmp/.X11-unix/:/tmp/.X11-unix -v /home/skymind/car-plate-recognition/Carplate-yolov5/weights:/car-plate-recognition/Carplate-yolov5/weights cargate python3 send_video.py --source 0
+sudo docker run --privileged -it --rm --runtime nvidia --network host --device /dev/video0:/dev/video0:mrw -e DISPLAY=$DISPLAY -v /tmp/argus_socket:/tmp/argus_socket -v /tmp/.X11-unix/:/tmp/.X11-unix -v /home/skymind/car-plate-recognition/Carplate-yolov5/weights:/car-plate-recognition/Carplate-yolov5/weights cargate python3 send_video.py --source 0
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The following changes include installation of the Jetson.GPIO library and running of the container in "privileged" mode which will allow you to access the GPIO pins from within a container. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Adding Github Action's automation feature

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [x] Others  (State here -> xxx ) Jetson Nano 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged