### PR TITLE
Use pytorch base image (Dockerfile-origin)

### DIFF
--- a/Dockerfile-origin
+++ b/Dockerfile-origin
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/l4t-base:r32.5.0
+FROM nvcr.io/nvidia/l4t-pytorch:r32.5.0-pth1.7-py3
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Tried to switch to ```nvcr.io/nvidia/l4t-base``` base image but was not successful and received error mid-way during build, switching back to ```nvcr.io/nvidia/l4t-pytorch:r32.5.0-pth1.7-py3``` base image.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Adding Github Action's automation feature

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [x] Others  (State here -> Jetson Nano )  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged